### PR TITLE
ignore projections with no alternate key

### DIFF
--- a/src/Projections.ts
+++ b/src/Projections.ts
@@ -155,7 +155,7 @@ const splitOutAlternates = (pair: ProjectionPair): SingleProjectionPair[] => {
     return [[main, { alternate }]] as SingleProjectionPair[];
   }
 
-  throw new Error(`${main} is missing the alternate key`);
+  return [];
 };
 
 /**


### PR DESCRIPTION
This is preventing me from alternating files for projectionist files that don't have alternate files